### PR TITLE
feat: add local cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It allows you to quickly start your own project. Note that this template is most
 
 - interaction handler (application commands, message components and modals) with usage examples
 - event handler
-- built-in support for interaction cooldown
+- built-in support for interaction cooldown (global and per guild or direct message)
 - environment validation
 - separate application commands registration script
 - [Docker](https://www.docker.com/) with [Docker Compose](https://docs.docker.com/compose/)
@@ -57,6 +57,28 @@ Simple as that!
 
 > **Note**  
 > Keep in mind that any interaction key, whether it's an application command name or a `customId` property, must be unique throughout your bot.
+
+#### Cooldown support
+
+To enable cooldown support in your handler, you need to define either `cooldownDuration` (per guild or direct message) or `globalCooldownDuration` in the `options` object.
+
+By default, each new cooldown is saved to the database if it is equal to or longer than the `MINIMUM_DURATION_TO_SAVE` constant (**60** by default) in the `src/utils/validation/cooldown.ts` file.
+
+```ts
+export default new MessageComponentInteractionHandler<ButtonInteraction>({
+  id: 'example',
+  options: {
+    cooldownDuration: 60, // per guild or direct message
+    globalCooldownDuration: 60,
+  },
+  execute: async (interaction) => {
+    // Your code goes here...
+  },
+});
+```
+
+> **Note**  
+> You can only specify one cooldown scope per handler.
 
 ## Support
 

--- a/prisma/migrations/20231124012612_initialization/migration.sql
+++ b/prisma/migrations/20231124012612_initialization/migration.sql
@@ -1,6 +1,7 @@
 -- CreateTable
 CREATE TABLE "cooldown" (
     "id" SERIAL NOT NULL,
+    "scope_key" TEXT,
     "interaction_key" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "expires_at" TIMESTAMP(3) NOT NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model Cooldown {
   id             Int      @id @default(autoincrement())
+  scopeKey       String?  @map("scope_key")
   interactionKey String   @map("interaction_key")
   userId         String   @map("user_id")
   expiresAt      DateTime @map("expires_at")

--- a/src/handlers/events/client-ready.ts
+++ b/src/handlers/events/client-ready.ts
@@ -13,8 +13,7 @@ export default new EventHandler({
 
     // Delete expired cooldowns every 5 minutes.
     Cron('*/5 * * * *', async () => {
-      // noinspection JSUnresolvedReference
-      await databaseClient.cooldown.deleteMany({
+      await databaseClient['cooldown']['deleteMany']({
         where: {
           expiresAt: {
             lt: new Date(),

--- a/src/structures.ts
+++ b/src/structures.ts
@@ -20,13 +20,24 @@ type AnyMessageComponentInteraction =
   | AnySelectMenuInteraction
   | ButtonInteraction;
 
+type OptionsWithCooldown = {
+  cooldownDuration?: number;
+  globalCooldownDuration?: never;
+};
+
+type OptionsWithGlobalCooldown = {
+  cooldownDuration?: never;
+  globalCooldownDuration?: number;
+};
+
+export type InteractionHandlerOptions =
+  | OptionsWithCooldown
+  | OptionsWithGlobalCooldown;
+
 export abstract class InteractionHandler<
   T extends BaseInteraction = BaseInteraction,
 > {
-  public readonly options: {
-    // Cooldown duration in seconds.
-    cooldownDuration?: number;
-  };
+  public readonly options: InteractionHandlerOptions;
   public readonly execute: (interaction: T) => Promise<void>;
 
   protected constructor({ options, execute }: InteractionHandler<T>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ declare module 'discord.js' {
       messageComponents: Map<string, MessageComponentInteractionHandler>;
       modalSubmits: Map<string, ModalSubmitInteractionHandler>;
     };
-    cooldowns: Map<string, CooldownMap>;
+    cooldowns: Map<Snowflake, Map<string, CooldownMap>>;
+    globalCooldowns: Map<string, CooldownMap>;
   }
 }

--- a/src/utils/validation/cooldown.ts
+++ b/src/utils/validation/cooldown.ts
@@ -1,0 +1,77 @@
+import { inlineCode } from 'discord.js';
+
+import type { InteractionValidationData } from '~/utils/validation/index.js';
+
+import { databaseClient } from '~/utils/database.js';
+import { getRelativeTime } from '~/utils/date.js';
+
+const MINIMUM_DURATION_TO_SAVE = 60;
+
+const replyWithRemainingDuration = async (
+  interaction: InteractionValidationData['interaction'],
+  expiresAt: Date,
+) => {
+  await interaction.reply({
+    content: `Hold up! Try again ${inlineCode(
+      getRelativeTime(expiresAt),
+    )}, please.`,
+    ephemeral: true,
+  });
+};
+
+export const validateInteractionCooldown = async ({
+  interactionKey,
+  interaction,
+  duration,
+  isGlobal,
+}: {
+  interactionKey: InteractionValidationData['interactionKey'];
+  interaction: InteractionValidationData['interaction'];
+  duration: number;
+  isGlobal: boolean;
+}) => {
+  const { client, user } = interaction;
+  const interactionGuildIdOrDM = interaction.guildId ?? 'DM';
+
+  if (!isGlobal && !client.cooldowns.has(interactionGuildIdOrDM)) {
+    client.cooldowns.set(interactionGuildIdOrDM, new Map());
+  }
+
+  const scopeMap = isGlobal
+    ? client.globalCooldowns
+    : client.cooldowns.get(interactionGuildIdOrDM)!;
+
+  if (!scopeMap.has(interactionKey)) {
+    scopeMap.set(interactionKey, new Map());
+  }
+
+  const cooldownMap = scopeMap.get(interactionKey)!;
+
+  if (!cooldownMap.has(user.id)) {
+    const durationInMilliseconds = duration * 1000;
+    const expiresAt = new Date(Date.now() + durationInMilliseconds);
+
+    cooldownMap.set(user.id, expiresAt);
+
+    if (duration >= MINIMUM_DURATION_TO_SAVE) {
+      await databaseClient['cooldown'].create({
+        data: {
+          scopeKey: isGlobal ? null : interactionGuildIdOrDM,
+          interactionKey,
+          userId: user.id,
+          expiresAt,
+        },
+      });
+    }
+
+    setTimeout(() => {
+      cooldownMap.delete(user.id);
+    }, durationInMilliseconds);
+
+    return true;
+  }
+
+  await replyWithRemainingDuration(interaction, cooldownMap.get(user.id)!);
+
+  return false;
+};

--- a/src/utils/validation/index.ts
+++ b/src/utils/validation/index.ts
@@ -1,0 +1,30 @@
+import type { AutocompleteInteraction, Interaction } from 'discord.js';
+
+import type { InteractionHandlerOptions } from '~/structures.js';
+
+import { validateInteractionCooldown } from '~/utils/validation/cooldown.js';
+
+export type InteractionValidationData = {
+  interactionKey: string;
+  interaction: Exclude<Interaction, AutocompleteInteraction>;
+  options: InteractionHandlerOptions;
+};
+
+export const validateInteraction = async ({
+  interactionKey,
+  interaction,
+  options,
+}: InteractionValidationData) => {
+  const { cooldownDuration, globalCooldownDuration } = options;
+
+  if (cooldownDuration || globalCooldownDuration) {
+    return validateInteractionCooldown({
+      interactionKey,
+      interaction,
+      duration: (cooldownDuration || globalCooldownDuration) as number,
+      isGlobal: !!globalCooldownDuration,
+    });
+  }
+
+  return true;
+};


### PR DESCRIPTION
This pull request adds support for using cooldown either **locally** (cooldown is checked in each guild and direct message individually for each user) or **globally**. Previously, the cooldown system was designed to only work globally. This feature allows you to specify either `cooldownDuration` or `globalCooldownDuration` in your interaction handler options.